### PR TITLE
Switch to ubuntu/squid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   proxy:
-    image: datadog/squid
+    image: ubuntu/squid
     ports:
       - "8080:3128"
     volumes:


### PR DESCRIPTION
The old `datadog/squid` appears no longer available ("page not found" for https://hub.docker.com/r/datadog/squid).